### PR TITLE
Add debian packaging metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "ellington"
 version = "0.1.0"
 authors = ["Adam Harries <harries.adam@gmail.com>"]
 build = "build.rs"
+readme = "README.md"
 
 [lib]
 name = "libellington"
@@ -43,3 +44,11 @@ commandspec = "0.10"
 # This will download lots of data! 
 data_driven_tests = []
 extended_tests = []
+
+[package.metadata.deb]
+section = "sound"
+depends = "$auto, ffmpeg, id3v2, mp4v2-utils"
+extended-description = """\
+An experimental tool for automatically calculating the BPM of audio files \
+in a library of (mostly) swing music, as well as a testbed for trying out new
+BPM algorithms and techniques for the above."""

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -56,7 +56,6 @@ impl Library {
     /*
         Read a library from an itunes xml/plist file
      */
-    // #[flame]
     pub fn from_itunes_xml(filename: &str) -> Option<Library> {
         let file = File::open(filename).ok()?;
 
@@ -108,7 +107,6 @@ impl Library {
         Read a library as a list of audio files, with one
         audio file path per line
      */
-    // #[flame]
     pub fn from_stdin() -> Option<Library> {
         // each line in stdin is assumed to be a path to a track name
         let stdin = io::stdin();
@@ -136,7 +134,6 @@ impl Library {
         Read a library from a directory, recursively exploring the 
         file hierarchy, and finding audio files.
      */
-    // #[flame]
     pub fn from_directory_rec(path: &PathBuf) -> Option<Library> {
         let mut entries = 0;
         let mut io_errors = 0;

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1,6 +1,7 @@
 pub mod ellingtondata;
 pub mod filemetadata;
 pub mod trackmetadata;
+pub mod statistics; 
 
 use library::ellingtondata::*;
 use library::filemetadata::FileMetadata;
@@ -231,6 +232,41 @@ impl Library {
     }
 
     /*
+        Write ellington metadata to the audio file comment fields
+     */
+    pub fn write_metadata_to_audio_files(self: &Self, append: bool) -> () {
+        for entry in &self.tracks {
+            match TrackMetadata::write_ellington_data(
+                &PathBuf::from(entry.location.clone()),
+                &entry.filedata,
+                &entry.eldata,
+                append,
+            ) {
+                Some(()) => info!("Successfully wrote metadata to file {:?}", entry.location),
+                None => error!("Failed to write metadata to file {:?}", entry.location),
+            };
+        }
+    }
+
+    /*
+        Clear the ellington metadata from the audio file comment fields
+     */
+    pub fn clear_data_from_audio_files(self: &Self) -> () {
+        for entry in &self.tracks {
+            match TrackMetadata::clear_ellington_data(
+                &PathBuf::from(entry.location.clone()),
+                &entry.filedata,
+            ) {
+                Some(()) => info!(
+                    "Successfully cleared ellington metadata from file {:?}",
+                    entry.location
+                ),
+                None => error!("Failed to clear metadata from file {:?}", entry.location),
+            };
+        }
+    }
+
+    /*
         Run an analysis pipeline over each audio track in the library
      */
     pub fn run_pipeline<P: Pipeline>(self: &mut Self) -> () {
@@ -269,41 +305,6 @@ impl Library {
                     error!("Failed to calculate bpm for entry: {:?}", entry);
                 }
             }
-        }
-    }
-
-    /*
-        Write ellington metadata to the audio file comment fields
-     */
-    pub fn write_metadata_to_audio_files(self: &Self, append: bool) -> () {
-        for entry in &self.tracks {
-            match TrackMetadata::write_ellington_data(
-                &PathBuf::from(entry.location.clone()),
-                &entry.filedata,
-                &entry.eldata,
-                append,
-            ) {
-                Some(()) => info!("Successfully wrote metadata to file {:?}", entry.location),
-                None => error!("Failed to write metadata to file {:?}", entry.location),
-            };
-        }
-    }
-
-    /*
-        Clear the ellington metadata from the audio file comment fields
-     */
-    pub fn clear_data_from_audio_files(self: &Self) -> () {
-        for entry in &self.tracks {
-            match TrackMetadata::clear_ellington_data(
-                &PathBuf::from(entry.location.clone()),
-                &entry.filedata,
-            ) {
-                Some(()) => info!(
-                    "Successfully cleared ellington metadata from file {:?}",
-                    entry.location
-                ),
-                None => error!("Failed to clear metadata from file {:?}", entry.location),
-            };
         }
     }
 }

--- a/src/library/statistics.rs
+++ b/src/library/statistics.rs
@@ -1,0 +1,18 @@
+use library::Library;
+// use histogram::Histogram;
+
+pub struct Statistics { 
+    //some data 
+}
+
+impl From<Library> for Statistics {
+    fn from(library: Library) -> Self { 
+        // // begin by iterating across the library to capture the data we care about
+        // let stats = library.entries.into_iter().filter_map(|entry|{
+        //     // compare entry.metadata with entry.eldata
+
+        // });
+
+        Statistics {}
+    }
+}


### PR DESCRIPTION
This enables debian builds to be created using `cargo install cargo-deb; cargo deb`.