### PR TITLE
Oneshot tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ walkdir = "2"
 log = "0.4"
 env_logger  = "0.5.1"
 commandspec = "0.10"
+nom = "4.0.0"
 
 [build-dependencies]
 commandspec = "0.10"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -51,8 +51,6 @@ subcommands:
                 long: append 
                 required: false 
                 takes_value: false
-
-
     - clear: 
         about: Clear ellington metadata from audio files in a library
         version: "0.1.0"
@@ -63,3 +61,20 @@ subcommands:
                 required: true
                 index: 1 
                 index: 1 
+    - oneshot: 
+        about: Run a tempo estimation algorithm on a single audio track with a comment, and add data to the comment
+        version: "0.1.0"
+        author: Adam Harries <harries.adam@gmail.com> 
+        args: 
+            - audiofile: 
+                help: The audio file to process
+                short: a
+                long: audiofile
+                required: true 
+                takes_value: true
+            - comment: 
+                help: The existing comment in the audio file. This command will append calculated data to this comment. If no comment is specified, ellington will return a fresh metadata block.
+                short: c 
+                long: comment
+                required: false
+                takes_value: true 

--- a/src/ellington.rs
+++ b/src/ellington.rs
@@ -9,6 +9,9 @@ extern crate log;
 extern crate env_logger;
 
 #[macro_use]
+extern crate nom;
+
+#[macro_use]
 extern crate clap;
 use clap::App;
 use clap::ArgMatches;
@@ -24,6 +27,7 @@ use le::pipelines::FfmpegNaivePipeline;
 use le::pipelines::Pipeline;
 
 fn check_callable(program: &'static str) -> Option<()> {
+    //TODO: this needs to be written to capture the various output streams, as it pollutes ellington's output otherwise
     match execute!(r"which {program}", program = program) {
         Err(_) => {
             println!("Cannot find program '{}' - please make sure it's installed before running this command", program);
@@ -123,7 +127,8 @@ fn clear_audio_files(matches: &ArgMatches) -> () {
 }
 
 fn oneshot_audio_file(matches: &ArgMatches) -> () {
-    check_callable("ffmpeg").unwrap();
+    // TODO: Reinstate this - see the comment above
+    // check_callable("ffmpeg").unwrap();
 
     let audiofile: &str = match matches.value_of("audiofile") {
         Some(ap) => {
@@ -142,7 +147,7 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
     match (estimation, matches.value_of("comment")) {
         // Comment and bpm.
         (Some(e), Some(c)) => {
-            // get our new ellington data: 
+            // get our new ellington data:
             let ed = EllingtonData::with_algorithm(String::from("naive"), e);
 
             match ed.update_data(&String::from(c), true) {
@@ -157,10 +162,10 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
         }
         // Bpm, no comment
         (Some(e), None) => {
-            // get our new ellington data: 
+            // get our new ellington data:
             let ed = EllingtonData::with_algorithm(String::from("naive"), e);
 
-            match ed.serialise() {
+            match ed.format() {
                 Ok(new_comment) => {
                     info!("Got new comment: {:?}", new_comment);
                     println!("{}", new_comment);
@@ -169,7 +174,6 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
                     info!("Updating procedure failed for reason: {:?}", f);
                 }
             }
-
         }
         // No bpm, but a comment
         (None, Some(c)) => {

--- a/src/ellington.rs
+++ b/src/ellington.rs
@@ -2,7 +2,6 @@
     ellington - the ellington tool for processing and bpming audio libraries
 */
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 #[macro_use]
@@ -124,6 +123,8 @@ fn clear_audio_files(matches: &ArgMatches) -> () {
 }
 
 fn oneshot_audio_file(matches: &ArgMatches) -> () {
+    check_callable("ffmpeg").unwrap();
+
     let audiofile: &str = match matches.value_of("audiofile") {
         Some(ap) => {
             info!("Processing audio file at {:?}", ap);
@@ -147,7 +148,7 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
             match ed.update_data(&String::from(c), true) {
                 Ok(new_comment) => {
                     info!("Got new comment: {:?}", new_comment);
-                    println!("{:?}", new_comment);
+                    println!("{}", new_comment);
                 }
                 f => {
                     info!("Updating procedure failed for reason: {:?}", f);
@@ -162,7 +163,7 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
             match ed.serialise() {
                 Ok(new_comment) => {
                     info!("Got new comment: {:?}", new_comment);
-                    println!("{:?}", new_comment);
+                    println!("{}", new_comment);
                 }
                 f => {
                     info!("Updating procedure failed for reason: {:?}", f);
@@ -173,7 +174,7 @@ fn oneshot_audio_file(matches: &ArgMatches) -> () {
         // No bpm, but a comment
         (None, Some(c)) => {
             info!("Bpm estimation failed, returning old comment");
-            println!("{:?}", c);
+            println!("{}", c);
         }
         // Neither
         _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-
-
 /*
     libellington - the core library + functionality for the ellington tool.
 */
@@ -42,7 +40,6 @@ pub mod shelltools;
 pub fn trueish() -> bool {
     true
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+
+
 /*
     libellington - the core library + functionality for the ellington tool.
 */
@@ -5,6 +7,9 @@
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+
+#[macro_use]
+extern crate nom;
 
 extern crate byteorder;
 
@@ -37,6 +42,7 @@ pub mod shelltools;
 pub fn trueish() -> bool {
     true
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/library/ellingtondata.rs
+++ b/src/library/ellingtondata.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 pub type Algorithm = String;
 pub type Bpm = i64;
 
+#[derive(Debug)]
 pub enum UpdateError {
     NoDataInComment,
     FailedToSerialise,
@@ -29,7 +30,13 @@ impl EllingtonData {
         }
     }
 
-    fn serialise(self: &Self) -> UpdateResult<String> {
+    pub fn with_algorithm(a: Algorithm, b: Bpm) -> EllingtonData {
+        let mut map = BTreeMap::new();
+        map.insert(a, b);
+        EllingtonData { algs: map }
+    }
+
+    pub fn serialise(self: &Self) -> UpdateResult<String> {
         serde_json::to_string(self)
             .ok()
             .and_then(|s| Some(s.replace(":", "#")))

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1,7 +1,7 @@
 pub mod ellingtondata;
 pub mod filemetadata;
+pub mod statistics;
 pub mod trackmetadata;
-pub mod statistics; 
 
 use library::ellingtondata::*;
 use library::filemetadata::FileMetadata;

--- a/src/library/statistics.rs
+++ b/src/library/statistics.rs
@@ -1,12 +1,12 @@
 use library::Library;
 // use histogram::Histogram;
 
-pub struct Statistics { 
-    //some data 
+pub struct Statistics {
+    //some data
 }
 
 impl From<Library> for Statistics {
-    fn from(library: Library) -> Self { 
+    fn from(library: Library) -> Self {
         // // begin by iterating across the library to capture the data we care about
         // let stats = library.entries.into_iter().filter_map(|entry|{
         //     // compare entry.metadata with entry.eldata

--- a/src/library/statistics.rs
+++ b/src/library/statistics.rs
@@ -6,7 +6,7 @@ pub struct Statistics {
 }
 
 impl From<Library> for Statistics {
-    fn from(library: Library) -> Self {
+    fn from(_library: Library) -> Self {
         // // begin by iterating across the library to capture the data we care about
         // let stats = library.entries.into_iter().filter_map(|entry|{
         //     // compare entry.metadata with entry.eldata

--- a/src/library/trackmetadata/id3v2_call.rs
+++ b/src/library/trackmetadata/id3v2_call.rs
@@ -140,11 +140,11 @@ impl MetadataWriter for Id3v2Call {
             .filter_map(|line| Id3v2Comment::parse(&line))
             .collect();
 
-        if comments.len() == 0 && append { 
+        if comments.len() == 0 && append {
             let empty = Id3v2Comment {
                 description: "".to_string(),
                 language: "".to_string(),
-                comment: "".to_string()
+                comment: "".to_string(),
             };
             comments.push(empty);
         }

--- a/src/library/trackmetadata/mod.rs
+++ b/src/library/trackmetadata/mod.rs
@@ -27,7 +27,7 @@ impl TrackMetadata {
             Some(v) => {
                 for c in v {
                     // parse the comment into some ellington data
-                    match EllingtonData::parse_data(&c) {
+                    match EllingtonData::parse(&c) {
                         Some(mut ed) => {
                             info!("Found ellington metadata: {:?}", ed);
                             algs.append(&mut ed.algs);

--- a/src/library/trackmetadata/mp4tools_call.rs
+++ b/src/library/trackmetadata/mp4tools_call.rs
@@ -84,7 +84,7 @@ impl MetadataWriter for Mp4ToolsCall {
     fn write_ellington_data(location: &Path, ed: &EllingtonData, append: bool) -> WriteResult {
         // Reparse the file to get the comment data
         let original = match &Self::from_file(location)?.comments {
-            Some(comms) => comms[0].clone(), 
+            Some(comms) => comms[0].clone(),
             None => "".to_string(),
         };
 


### PR DESCRIPTION
This PR adds the ability to use ellington as a "oneshot" tool, calculating bpm information for a single file, in the following manner: `ellington oneshot -a <audio file path> -c <original comment>` 

As before, this assumes that we want to store ellington metadata in a comment. It might be more useful to have other kinds of oneshot tools later. 

This is rather related to issue #14 